### PR TITLE
fixed limit and offeset bug

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -374,11 +374,11 @@ trait ElasticquentTrait
             $params['fields'] = implode(",", $fieldsParam);
         }
 
-        if ($limit) {
+        if (is_numeric($limit)) {
             $params['size'] = $limit;
         }
 
-        if ($offset) {
+        if (is_numeric($offset)) {
             $params['from'] = $offset;
         }
 


### PR DESCRIPTION
Fixed limit and offeset bug - When 0 is passed for limit or offset, the parameters did not get applied.
