### PR TITLE
Adding ability to set a sort query on the search

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -228,6 +228,7 @@ Here's the list of available paramers:
 - `sourceFields` - Limits returned set to the selected fields only
 - `limit` - Number of records to return
 - `offset` - Sets the record offset (use for paging results)
+- `sort` - Your sort query
 
 ### Search Collections
 

--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -241,7 +241,7 @@ trait ElasticquentTrait
      * @param   int $offset
      * @return  ResultCollection
      */
-    public static function searchByQuery($query = null, $aggregations = null, $sourceFields = null, $limit = null, $offset = null)
+    public static function searchByQuery($query = null, $aggregations = null, $sourceFields = null, $limit = null, $offset = null, $sort = null)
     {
         $instance = new static;
 
@@ -257,6 +257,10 @@ trait ElasticquentTrait
 
         if ($aggregations) {
             $params['body']['aggs'] = $aggregations;
+        }
+        
+        if ($sort) {
+            $params['body']['sort'] = $sort;
         }
 
         $result = $instance->getElasticSearchClient()->search($params);


### PR DESCRIPTION
Currently speaking there is no way to set a way to apply a sort on the Elasticquent query.

This is an additional parameter and thus a non-breaking change adding the ability to apply a sort query to the Elasticquent search.