### PR TITLE
Add "Partial-Update to Indexed Document" Function

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -327,6 +327,21 @@ trait ElasticquentTrait
     }
 
     /**
+     * Partial Update to Indexed Document
+     *
+     * @return array
+     */
+    public function updateIndex()
+    {
+        $params = $this->getBasicEsParams();
+
+        // Get our document body data.
+        $params['body']['doc'] = $this->getIndexDocumentData();
+
+        return $this->getElasticSearchClient()->update($params);
+    }
+
+    /**
      * Get Search Document
      *
      * Retrieve an ElasticSearch document


### PR DESCRIPTION
* Added updateIndex() function to eloquent model to be able to partial update.

### Details
Normally if we want to update an existing document, we have to reindex or replace it. 

By ElasticSearch's `update` API, it can be able to do *partial updates* to a document. This `update` API is more efficient and reliable. According to *"elastic" guide, 

"The difference is that this process happens within a shard, thus avoiding the network overhead of multiple requests. By reducing the time between the retrieve and reindex steps, we also reduce the likelihood of there being conflicting changes from other processes."

In this `updateIndex()`, existing scalar fields (columns) are overwritten, and new fields (columns) are added to the index.